### PR TITLE
Update object-definition.js

### DIFF
--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -86,6 +86,13 @@ ObjectDefinition.prototype.build = function(object) {
     throw new Error('Error preparing data for object: ' + JSON.stringify(object));
   }
 
+  //removes empty object properties (which are considered truthy in handlebars)
+  self = _.pick(self, function(prop) {
+      if (!(_.isObject(prop) && _.isEmpty(prop))) {
+          return prop;
+      }
+  });
+
   return self;
 };
 


### PR DESCRIPTION
removes empty object properties at the end of objectDefinition build method

If I don't have any optional properties, the parameters.optionalProps in the endpoint.handlebars template file is an empty object. So {{#if parameters.optionalProps}} will still be true, and output the heading
